### PR TITLE
fix NameError in test

### DIFF
--- a/spec/blocking_flag_spec.rb
+++ b/spec/blocking_flag_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 
 describe ServerEngine::BlockingFlag do
   subject { BlockingFlag.new }

--- a/spec/daemon_logger_spec.rb
+++ b/spec/daemon_logger_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 
 describe ServerEngine::DaemonLogger do
   before { FileUtils.mkdir_p("tmp") }

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -1,3 +1,4 @@
+require 'serverengine/daemon'
 
 describe ServerEngine::Daemon do
   include_context 'test server and worker'

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 
 describe ServerEngine::MultiWorkerServer do
   include_context 'test server and worker'

--- a/spec/signal_thread_spec.rb
+++ b/spec/signal_thread_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 
 describe ServerEngine::SignalThread do
   it 'start and stop' do

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 
 describe ServerEngine::Supervisor do
   include_context 'test server and worker'


### PR DESCRIPTION
I've noticed that all test fails because of NameError with `bundle exec rspec`. 

I could run test with this fix. Still many test fails (I use ruby-2.0.0-p195), though. 

```
1) ServerEngine::Daemon run and graceful stop
 Failure/Error: test_state(:server_stop_graceful).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/daemon_spec.rb:17:in `block (2 levels) in <top (required)>'

2) ServerEngine::Daemon signals
 Failure/Error: test_state(:server_reload).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/daemon_spec.rb:31:in `block (2 levels) in <top (required)>'

3) ServerEngine::MultiWorkerServer scale up
 Failure/Error: test_state(:worker_run).should == 3
   expected: 3
        got: 4 (using ==)
 # ./spec/multi_process_server_spec.rb:21:in `block (3 levels) in <top (required)>'

4) ServerEngine::MultiWorkerServer scale up
 Failure/Error: test_state(:worker_run).should == 3
   expected: 3
        got: 6 (using ==)
 # ./spec/multi_process_server_spec.rb:21:in `block (3 levels) in <top (required)>'

5) ServerEngine::MultiWorkerServer scale down
 Failure/Error: test_state(:worker_stop).should == 2
   expected: 2
        got: 0 (using ==)
 # ./spec/multi_process_server_spec.rb:49:in `block (3 levels) in <top (required)>'

6) ServerEngine::SignalThread call handler
 Failure/Error: n.should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/signal_thread_spec.rb:20:in `block (2 levels) in <top (required)>'

7) ServerEngine::SignalThread signal in handler
 Failure/Error: n.should == 3
   expected: 3
        got: 0 (using ==)
 # ./spec/signal_thread_spec.rb:49:in `block (2 levels) in <top (required)>'

8) ServerEngine::SignalThread stop in handler
 Failure/Error: t = SignalThread.new do |st|
 ThreadError:
   can't be called from trap context
 # ./lib/serverengine/signal_thread.rb:138:in `unlock'
 # ./lib/serverengine/signal_thread.rb:138:in `ensure in enqueue'
 # ./lib/serverengine/signal_thread.rb:138:in `enqueue'
 # ./lib/serverengine/signal_thread.rb:46:in `block in trap'
 # ./lib/serverengine/signal_thread.rb:26:in `call'
 # ./lib/serverengine/signal_thread.rb:26:in `new'
 # ./lib/serverengine/signal_thread.rb:26:in `initialize'
 # ./spec/signal_thread_spec.rb:55:in `new'
 # ./spec/signal_thread_spec.rb:55:in `block (2 levels) in <top (required)>'

9) ServerEngine::SignalThread should not deadlock
 Failure/Error: t.join
 ThreadError:
   can't be called from trap context
 # ./lib/serverengine/signal_thread.rb:138:in `unlock'
 # ./lib/serverengine/signal_thread.rb:138:in `ensure in enqueue'
 # ./lib/serverengine/signal_thread.rb:138:in `enqueue'
 # ./lib/serverengine/signal_thread.rb:46:in `block in trap'
 # ./spec/signal_thread_spec.rb:78:in `call'
 # ./spec/signal_thread_spec.rb:78:in `join'
 # ./spec/signal_thread_spec.rb:78:in `block (3 levels) in <top (required)>'

 # ./spec/signal_thread_spec.rb:77:in `each'
 # ./spec/signal_thread_spec.rb:77:in `block (2 levels) in <top (required)>'

10) ServerEngine::Supervisor start and graceful stop
 Failure/Error: test_state(:server_before_run).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/supervisor_spec.rb:18:in `block (2 levels) in <top (required)>'

11) ServerEngine::Supervisor immediate stop
 Failure/Error: test_state(:server_stop).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/supervisor_spec.rb:43:in `block (2 levels) in <top (required)>'

12) ServerEngine::Supervisor graceful restart
 Failure/Error: test_state(:server_stop).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/supervisor_spec.rb:62:in `block (2 levels) in <top (required)>'

13) ServerEngine::Supervisor immediate restart
 Failure/Error: test_state(:server_stop).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/supervisor_spec.rb:83:in `block (2 levels) in <top (required)>'

14) ServerEngine::Supervisor reload
 Failure/Error: test_state(:server_stop).should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/supervisor_spec.rb:104:in `block (2 levels) in <top (required)>'
```
