### PR TITLE
mutex `unlock`: cannot be called from trap context

### DIFF
--- a/lib/serverengine/signal_thread.rb
+++ b/lib/serverengine/signal_thread.rb
@@ -43,7 +43,11 @@ module ServerEngine
 
       old = @handlers[sig]
       if block
-        Kernel.trap(sig) { enqueue(sig) }
+        Kernel.trap(sig) do
+          Thread.new {
+            enqueue(sig)
+          }.run
+        end
         @handlers[sig] = block
       else
         Kernel.trap(sig, command)


### PR DESCRIPTION
Related with https://github.com/fluent/fluentd/pull/191. Since Ruby 2.0.0, We can't synchronize mutex in trap context.
There is another pull request https://github.com/frsyuki/serverengine/pull/5, but this fix looks better. 

Comparing with https://github.com/frsyuki/serverengine/pull/8, the number of errors were reduced into 3. 

```
1) ServerEngine::MultiWorkerServer scale up
 Failure/Error: test_state(:worker_run).should == 3
   expected: 3
        got: 5 (using ==)
 # ./spec/multi_process_server_spec.rb:22:in `block (3 levels) in <top (required)>'

2) ServerEngine::MultiWorkerServer scale down
 Failure/Error: test_state(:worker_stop).should == 2
   expected: 2
        got: 1 (using ==)
 # ./spec/multi_process_server_spec.rb:50:in `block (3 levels) in <top (required)>'

3) ServerEngine::SignalThread call handler
 Failure/Error: n.should == 1
   expected: 1
        got: 0 (using ==)
 # ./spec/signal_thread_spec.rb:21:in `block (2 levels) in <top (required)>'
```
