### PR TITLE
Enable to run tests with `rspec`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.fail_on_error = false
-  t.rspec_opts = %w[-rspec_helper]
 end
 
 task :default => [:spec, :build]


### PR DESCRIPTION
Currently we gets `NameError` when we run tests by `rspec` command. Moving requiring `spec_helper` from Rakefile to .rspec makes it possible to run tests by `rspec` in addition to `rake spec`. 

I prefer to run tests by `rspec` command because I can easily specify one file like

```
$ bundle exec rspec spec/path/to/hoge_spec.rb
```

although in the case of rake spec, I have to do like

```
$ bundle exec rake spec SPEC=spec/path/to/hoge_spec.rb
```

`SPEC=` is bothersome. 
