### PR TITLE
fix log rotate

### DIFF
--- a/lib/serverengine/daemon_logger.rb
+++ b/lib/serverengine/daemon_logger.rb
@@ -26,18 +26,11 @@ module ServerEngine
       rotate_age = config[:log_rotate_age] || 5
       rotate_size = config[:log_rotate_size] || 1048576
 
-      if dev.is_a?(String)
-        @path = dev
-        @io = File.open(@path, "a")
-        @io.sync = true
-      else
-        @io = dev
-      end
+      super(dev, rotate_age, rotate_size)
+      @io = @logdev.dev
 
       hook_stdout! if @hook_stdout
       hook_stderr! if @hook_stderr
-
-      super(@io, rotate_age, rotate_size)
 
       self.level = config[:log_level] || 'debug'
     end

--- a/spec/daemon_logger_spec.rb
+++ b/spec/daemon_logger_spec.rb
@@ -3,29 +3,38 @@ describe ServerEngine::DaemonLogger do
   before { FileUtils.mkdir_p("tmp") }
   before { FileUtils.rm_f("tmp/se1.log") }
   before { FileUtils.rm_f("tmp/se2.log") }
+  before { FileUtils.rm_f("tmp/rotate.log") }
+  before { FileUtils.rm_f("tmp/rotate.log.0") }
+  before { FileUtils.rm_f("tmp/rotate.log.1") }
 
   subject { DaemonLogger.new("tmp/se1.log", log_stdout: false, log_stderr: false) }
+
+  # Read logfile with removing a log header such as
+  # # Logfile created on 2013-09-29 01:14:13 +0900 by logger.rb/36483\n
+  def open_logfile(filename)
+    File.readlines(filename).tap {|lines| lines.shift if lines.first[0] == '#' }.join
+  end
 
   it 'reopen' do
     subject.path = 'tmp/se2.log'
     subject.reopen!
     subject.warn "test"
 
-    File.read('tmp/se2.log').should =~ /test$/
+    open_logfile('tmp/se2.log').should =~ /test$/
   end
 
   it 'stderr hook 1' do
     subject.hook_stderr!
     STDERR.puts "test"
 
-    File.read('tmp/se1.log').should == "test\n"
+    open_logfile('tmp/se1.log').should == "test\n"
   end
 
   it 'stderr hook 2' do
     log = DaemonLogger.new("tmp/se1.log", log_stdout: false, log_stderr: true)
     STDERR.puts "test"
 
-    File.read('tmp/se1.log').should == "test\n"
+    open_logfile('tmp/se1.log').should == "test\n"
   end
 
   it 'stderr hook and reopen' do
@@ -34,12 +43,12 @@ describe ServerEngine::DaemonLogger do
     subject.reopen!
     STDERR.puts "test"
 
-    File.read('tmp/se2.log').should == "test\n"
+    open_logfile('tmp/se2.log').should == "test\n"
   end
 
   it 'default level is debug' do
     subject.debug 'debug'
-    File.read('tmp/se1.log').should =~ /debug$/
+    open_logfile('tmp/se1.log').should =~ /debug$/
   end
 
   it 'level set by int' do
@@ -84,5 +93,17 @@ describe ServerEngine::DaemonLogger do
     STDOUT.should_not_receive(:reopen)
     log = DaemonLogger.new(STDOUT)
     log.debug "stdout logging test"
+  end
+
+  it 'log_rotate' do
+    # NOTE: log_rotate_age must be >= 3 (it is specification of ::Logger)
+    log = DaemonLogger.new("tmp/rotate.log", log_rotate_age: 3, log_rotate_size: 1, log_stdout: false, log_stderr: false)
+    log.warn "1st"
+    log.warn "2nd"
+    log.warn "3rd"
+
+    open_logfile('tmp/rotate.log').should   =~ /3rd$/
+    open_logfile('tmp/rotate.log.0').should =~ /2nd$/
+    open_logfile('tmp/rotate.log.1').should =~ /1st$/
   end
 end


### PR DESCRIPTION
This patch fixes #9. 

However, I know that ruby's Logger would tell an error in multiprocess environments. See https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L630-L632

``` ruby
        if FileTest.exist?("#{@filename}.#{i}")
          File.rename("#{@filename}.#{i}", "#{@filename}.#{i+1}")
        end
```

For example, an error occurs if a sequence is as followings:

```
Process A: FileTest.exist?("#{@filename}.#{i}") #=> true
Process B: FileTest.exist?("#{@filename}.#{i}") #=> true
Process A: File.rename("#{@filename}.#{i}", "#{@filename}.#{i+1}") #=> success
Process B: File.rename("#{@filename}.#{i}", "#{@filename}.#{i+1}") #=> error!
```

Moreover, if sequence is as below, it results in worse

```
Process A: FileTest.exist?("test.log.1") #=> true
Process A: File.rename("test.log.1", "test.log.2")
Process A: FileTest.exist?("test.log.0") #=> true
Process A: File.rename("test.log.0", "test.log.1")
Process B: FileTest.exist?("test.log.1") #=> true
Process B: File.rename("test.log.1", "test.log.2") #=> test.log.2 is overwriten by test.log.0 originally
Process B: FileTest.exist?("test.log.0") #=> false
```

Supporting log rotation in serverengine may not fit (that is, also in fluentd v11). What do you think?
