### PR TITLE
Support ipv6 on windows

### DIFF
--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -27,11 +27,23 @@ module ServerEngine
         return UNIXSocket.new(path)
       end
 
-      def recv_tcp(peer, sent)
+      def recv(family, proto, peer, sent)
+        server_class = case proto
+                       when :tcp then TCPServer
+                       when :udp then UDPSocket
+                       else
+                         raise ArgumentError, "invalid protocol: #{proto}"
+                       end
+        peer.recv_io(server_class)
+      end
+
+      def recv_tcp(family, peer, sent)
+        return recv(family, :tcp, peer, sent)
         return peer.recv_io(TCPServer)
       end
 
-      def recv_udp(peer, sent)
+      def recv_udp(family, peer, sent)
+        return recv(family, :udp, peer, sent)
         return peer.recv_io(UDPSocket)
       end
     end
@@ -49,7 +61,7 @@ module ServerEngine
         if bind_ip.ipv6?
           sock = UDPSocket.new(Socket::AF_INET6)
         else
-          sock = UDPSocket.new
+          sock = UDPSocket.new(Socket::AF_INET)
         end
         sock.bind(bind_ip.to_s, port)
         return sock

--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -38,13 +38,11 @@ module ServerEngine
       end
 
       def recv_tcp(family, peer, sent)
-        return recv(family, :tcp, peer, sent)
-        return peer.recv_io(TCPServer)
+        recv(family, :tcp, peer, sent)
       end
 
       def recv_udp(family, peer, sent)
-        return recv(family, :udp, peer, sent)
-        return peer.recv_io(UDPSocket)
+        recv(family, :udp, peer, sent)
       end
     end
 

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -16,7 +16,7 @@ describe ServerEngine::SocketManager do
   end
 
   after(:each) do
-    File.unlink(server_path) if File.exist?(server_path)
+    File.unlink(server_path) if server_path.is_a?(String) && File.exist?(server_path)
   end
 
   context 'with thread' do


### PR DESCRIPTION
SocketManager Windows implementation has a bug not to handle IPv6 correctly.
The code to use IPv6 over SocketManager will crash with exit status 1, 3 or SIGSEGV.

This change fixes it.

Currently this pull-request is WIP.