### PR TITLE
Change required ruby version to >=2.0.0

### DIFF
--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.has_rdoc = false
 
-  gem.required_ruby_version = ">= 2.1.0"
+  gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "sigdump", ["~> 0.2.2"]
 


### PR DESCRIPTION
We have recently ran into the problem of not being able to install the fluentd-plugin-systemd gem which depends on the serverengine gem.

The machines we use run CentOS 7, for which the default ruby version available is 2.0.0. 

While I have seen the discussion around the commit which bumped the required version to the current one, I would like to add a few points:

- while 2.0.0 may not be maintained anymore, it still is the current officially available ruby version for CentOS 7, and possibly other distributions too
- the official ruby lang site does not specify a version, but refers you to using your package manager or in general trusts you to choose your version otherwise ([https://www.ruby-lang.org/en/documentation/installation/#yum](url))
- enforcing a ruby version requirement in a gem that other gems depend on, and in turn possibly breaking their updates / new installs is not ideal

While it would be possible to fork the project and maintain the fork, or take on the task of updating ruby on our machines, I feel like this would be better handled by the proposed change, or the removal of the constraint.
 
All my points assume that the project does not use any >=2.1.0 specific features.