### PR TITLE
Don't use unexpected exception for thread exit

### DIFF
--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -138,7 +138,10 @@ module ServerEngine
 
       def process_peer(peer)
         while true
-          pid, method, bind, port = *SocketManager.recv_peer(peer)
+          res = SocketManager.recv_peer(peer)
+          return if res.nil?
+
+          pid, method, bind, port = *res
           begin
             send_socket(peer, pid, method, bind, port)
           rescue => e
@@ -157,7 +160,10 @@ module ServerEngine
     end
 
     def self.recv_peer(peer)
-      len = peer.read(4).unpack('N').first
+      res = peer.read(4)
+      return nil if res.nil?
+
+      len = res.unpack('N').first
       data = peer.read(len)
       Marshal.load(data)
     end


### PR DESCRIPTION
Default report_on_exception value is true since ruby 2.5.
So current approach shows unexpected thread error in the log.

This is fluentd example:

```
2018-01-06 07:33:08 +0900 [info]: #0 starting fluentd worker pid=73966 ppid=73942 worker=0
#<Thread:0x00007f9ee9b05d08@/Users/repeatedly/dev/fluentd/serverengine/lib/serverengine/socket_manager.rb:139 run> terminated with exception (report_on_exception is true):
2018-01-06 07:33:08 +0900 [info]: #0 fluentd worker is now running worker=0
Traceback (most recent call last):
        1: from /Users/repeatedly/dev/fluentd/serverengine/lib/serverengine/socket_manager.rb:141:in `process_peer'
/Users/repeatedly/dev/fluentd/serverengine/lib/serverengine/socket_manager.rb:160:in `recv_peer': undefined method `unpack' for nil:NilClass (NoMethodError)
```