### PR TITLE
Add an option to disable Sigdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ Send `USR2` signal to reload configuration file.
 - **HUP:** immediate restart (available only when `worker_type` is "process")
 - **USR2:** reload config file and reopen log file
 - **INT:** detach process for live restarting (available only when `supervisor` and `enable_detach` parameters are true. otherwise graceful shutdown)
-- **CONT:** dump stacktrace and memory information to /tmp/sigdump-<pid>.log file
+- **CONT:** dump stacktrace and memory information to /tmp/sigdump-<pid>.log file. This can be
+    disabled by including `disable_sigdump: true` in the configuration.
 
 Immediate shutdown and restart send SIGQUIT signal to worker processes which kills the processes.
 Graceful shutdown and restart call `Worker#stop` method and wait for completion of `Worker#run` method.
@@ -463,6 +464,7 @@ Available methods are different depending on `worker_type`. ServerEngine support
   - **daemonize** enables daemonize (default: false)
   - **pid_path** sets the path to pid file (default: don't create pid file)
   - **supervisor** enables supervisor if it's true (default: false)
+  - **disable_sigdump** disables the handling of the `SIGCONT` signal and dumping of the thread (default: false)
   - **daemon_process_name** changes process name ($0) of server or supervisor process
   - **chuser** changes execution user
   - **chgroup** changes execution group

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -70,6 +70,11 @@ module ServerEngine
       nil
     end
 
+    def dump
+      Sigdump.dump unless config[:disable_sigdump]
+      nil
+    end
+
     def install_signal_handlers
       s = self
       if @command_pipe
@@ -89,7 +94,7 @@ module ServerEngine
             when "DETACH"
               s.detach(true)
             when "DUMP"
-              Sigdump.dump
+              s.dump
             end
           end
         end
@@ -104,7 +109,7 @@ module ServerEngine
             st.trap(@config[:signal_graceful_restart] || Signals::GRACEFUL_RESTART) { s.restart(true) }
             st.trap(@config[:signal_immediate_restart] || Signals::IMMEDIATE_RESTART) { s.restart(false) }
             st.trap(@config[:signal_reload] || Signals::RELOAD) { s.reload }
-            st.trap(@config[:signal_dump] || Signals::DUMP) { Sigdump.dump }
+            st.trap(@config[:signal_dump] || Signals::DUMP) { s.dump }
           end
         end
       end

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -148,6 +148,10 @@ module ServerEngine
       end
     end
 
+    def dump
+      _dump
+    end
+
     def install_signal_handlers
       s = self
       if @command_pipe
@@ -167,7 +171,7 @@ module ServerEngine
             when "DETACH"
               s.detach(true)
             when "DUMP"
-              Sigdump.dump
+              s.dump
             end
           end
         end
@@ -179,7 +183,7 @@ module ServerEngine
           st.trap(Signals::IMMEDIATE_RESTART) { s.restart(false) }
           st.trap(Signals::RELOAD) { s.reload }
           st.trap(Signals::DETACH) { s.detach(true) }
-          st.trap(Signals::DUMP) { Sigdump.dump }
+          st.trap(Signals::DUMP) { s.dump }
         end
       end
     end

--- a/lib/serverengine/worker.rb
+++ b/lib/serverengine/worker.rb
@@ -54,6 +54,10 @@ module ServerEngine
     def after_start
     end
 
+    def dump
+      Sigdump.dump unless config[:disable_sigdump]
+    end
+
     def install_signal_handlers
       w = self
       SignalThread.new do |st|
@@ -69,7 +73,7 @@ module ServerEngine
         }
         st.trap(Signals::DETACH) { w.stop }
 
-        st.trap(Signals::DUMP) { Sigdump.dump }
+        st.trap(Signals::DUMP) { w.dump }
       end
     end
 
@@ -77,5 +81,4 @@ module ServerEngine
       run
     end
   end
-
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -44,6 +44,10 @@ describe ServerEngine::Daemon do
       wait_for_stop
       test_state(:server_restart_immediate).should == 1
 
+      dm.dump
+      wait_for_stop
+      test_state(:server_dump).should == 1
+
       dm.stop(false)
       wait_for_stop
       test_state(:server_stop_immediate).should == 1

--- a/spec/server_worker_context.rb
+++ b/spec/server_worker_context.rb
@@ -146,6 +146,11 @@ module TestServer
     incr_test_state :server_detach
     super
   end
+
+  def dump
+    incr_test_state :server_dump
+    super
+  end
 end
 
 module TestWorker


### PR DESCRIPTION
As reported in https://github.com/treasure-data/serverengine/issues/92, the `Sigdump.dump` command on receiving a `SIGCONT` causes lots of unwanted files in systems where `systemd` is used to control services that use `serverengine`. 

This PR adds a new setting called `disable_sigdump` that can be used to disable this behaviour. It is `false` by default since we don't want to break anything for current users.