### PR TITLE
Improve socket manager security

### DIFF
--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 require 'fcntl'
+require 'serverengine/socket_manager'
 
 module ServerEngine
 
@@ -185,6 +186,7 @@ module ServerEngine
           @command_sender_pipe.binmode
           options[:in] = inpipe
         end
+        env['SERVERENGINE_SOCKETMANAGER_INTERNAL_TOKEN'] = SocketManager::INTERNAL_TOKEN
         pid = Process.spawn(env, *args, options)
         if @command_sender == "pipe"
           inpipe.close

--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -18,9 +18,16 @@
 require 'socket'
 require 'ipaddr'
 require 'time'
+require 'securerandom'
 
 module ServerEngine
   module SocketManager
+    # This token is used for communication between peers. If token is mismatched, messages will be discarded
+    INTERNAL_TOKEN = if ENV.has_key?('SERVERENGINE_SOCKETMANAGER_INTERNAL_TOKEN')
+                       ENV['SERVERENGINE_SOCKETMANAGER_INTERNAL_TOKEN']
+                     else
+                       SecureRandom.hex
+                     end
 
     class Client
       def initialize(path)
@@ -154,7 +161,8 @@ module ServerEngine
     end
 
     def self.send_peer(peer, obj)
-      data = Marshal.dump(obj)
+      data = [SocketManager::INTERNAL_TOKEN, obj]
+      data = Marshal.dump(data)
       peer.write [data.bytesize].pack('N')
       peer.write data
     end
@@ -165,7 +173,11 @@ module ServerEngine
 
       len = res.unpack('N').first
       data = peer.read(len)
-      Marshal.load(data)
+      data = Marshal.load(data)
+      token = data.first
+      return nil if SocketManager::INTERNAL_TOKEN != token
+
+      data.last
     end
 
     if ServerEngine.windows?

--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -96,7 +96,14 @@ module ServerEngine
       end
 
       def send_socket(peer, pid, method, bind, port)
-        sock = send(method, bind, port)  # calls listen_tcp or listen_udp
+        sock = case method
+               when :listen_tcp
+                 listen_tcp(bind, port)
+               when :listen_udp
+                 listen_udp(bind, port)
+               else
+                 raise ArgumentError, "Unknown method: #{method.inspect}"
+               end
 
         SocketManager.send_peer(peer, nil)
 

--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -70,7 +70,12 @@ module ServerEngine
         # when client changed working directory
         path = File.expand_path(path)
 
-        @server = UNIXServer.new(path)
+        begin
+          old_umask = File.umask(0077) # Protect unix socket from other users
+          @server = UNIXServer.new(path)
+        ensure
+          File.umask(old_umask)
+        end
 
         @thread = Thread.new do
           begin


### PR DESCRIPTION
- Change permission of unix socket
- Check method name, not call `send` directly
- Check token between peers
