### PR TITLE
signal: Don't ignore SIGDUMP_SIGNAL environment variable

### DIFF
--- a/lib/serverengine/signals.rb
+++ b/lib/serverengine/signals.rb
@@ -26,6 +26,6 @@ module ServerEngine
     IMMEDIATE_RESTART = :HUP
     RELOAD = :USR2
     DETACH = :INT
-    DUMP = :CONT
+    DUMP = ENV.has_key?('SIGDUMP_SIGNAL') ? ENV['SIGDUMP_SIGNAL'].to_sym : :CONT
   end
 end


### PR DESCRIPTION
sigdump provides `SIGDUMP_SIGNAL` environment variable to change the target signal.
serverengine now ignores this value so even if the user sets `SIGDUMP_SIGNAL`, serverengine still dumps sigdump result by `CONT`. This is unexpected behaviour.