### PR TITLE
fix gem versioning

### DIFF
--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sigdump", ["~> 0.2.2"]
 
   # rake v12.x doesn't work with rspec 2. rspec should be updated to 3
-  gem.add_development_dependency "rake", ["~> 11.0"]
-  gem.add_development_dependency "rspec", ["~> 2.13.0"]
+  gem.add_development_dependency "rake", [">= 11.0"]
+  gem.add_development_dependency "rspec", [">= 2.13.0"]
 
   gem.add_development_dependency 'rake-compiler-dock', ['~> 0.5.0']
-  gem.add_development_dependency 'rake-compiler', ['~> 0.9.4']
+  gem.add_development_dependency 'rake-compiler', ['>= 0.9.4']
 
   # build gem for a certain platform. see also Rakefile
   fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s


### PR DESCRIPTION
It works with rake 12.3.1, rspec 3.8.0  and rake-compiler 1.0.5 at least, so old versioning is not correct, IMO.