### PR TITLE
Fix dual stack mode issue for tcp socket with IPv6

### DIFF
--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -50,12 +50,11 @@ module ServerEngine
       private
 
       def listen_tcp_new(bind_ip, port)
-        # TCPServer.new doesn't set IPV6_V6ONLY flag, so use tcp_server_sockets instead.
-        tsock = Socket.tcp_server_sockets(bind_ip.to_s, port).first
+        # TCPServer.new doesn't set IPV6_V6ONLY flag, so use Addrinfo class instead.
+        # TODO: make backlog configurable if necessary
+        tsock = Addrinfo.tcp(bind_ip.to_s, port).listen(::Socket::SOMAXCONN)
         tsock.autoclose = false
-        sock = TCPServer.for_fd(tsock.fileno)
-        sock.listen(Socket::SOMAXCONN)  # TODO make backlog configurable if necessary
-        return sock
+        TCPServer.for_fd(tsock.fileno)
       end
 
       def listen_udp_new(bind_ip, port)

--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -50,7 +50,10 @@ module ServerEngine
       private
 
       def listen_tcp_new(bind_ip, port)
-        sock = TCPServer.new(bind_ip.to_s, port)
+        # TCPServer.new doesn't set IPV6_V6ONLY flag, so use tcp_server_sockets instead.
+        tsock = Socket.tcp_server_sockets(bind_ip.to_s, port).first
+        tsock.autoclose = false
+        sock = TCPServer.for_fd(tsock.fileno)
         sock.listen(Socket::SOMAXCONN)  # TODO make backlog configurable if necessary
         return sock
       end


### PR DESCRIPTION
See fluentd issue for the detail: https://github.com/fluent/fluentd/issues/2682
`TCPServer.new` doesn't set `IPV6_V6ONLY` and no parameter for `IPV6_V6ONLY`.
`Socket.tcp_server_sockets` set `IPV6_V6ONLY` internally, so use it instead.

Test echo server sciprt for checking the behaviour.
- TCPServer

```
require "socket"

ths = []
['0.0.0.0', '::'].each { |host|
  ths << Thread.new {
    gs = TCPServer.new(host, 2300)

    while true
      Thread.start(gs.accept) do |s|
        p s
        print(s, " is accepted in #{host}\n")
        while s.gets
          s.write($_)
        end
        print(s, " is gone\n")
        s.close
      end
    end
  }
}

ths.each { |th| th.join }
```

- Socket.tcp_server_sockets

```
require "socket"

ths = []
['0.0.0.0', '::'].each { |host|
  ths << Thread.new {
    gs = Socket.tcp_server_sockets(host, 2300).first
    gs.autoclose = false
    gs = TCPServer.for_fd(gs.fileno)

    while true
      Thread.start(gs.accept) do |s|
        p s
        print(s, " is accepted in #{host}\n")
        while s.gets
          s.write($_)
        end
        print(s, " is gone\n")
        s.close
      end
    end
  }
}

ths.each { |th| th.join }
```

- tcp client

```
require 'socket'

['0.0.0.0', '::'].each { |host|
  socket = TCPSocket.open(host, 2300)
  socket.print("hello\n")
  socket.flush
  puts response = socket.gets
  socket.close
}
```