### PR TITLE
Fix incomplete Windows support of MultiSpawnServer

### DIFF
--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -120,8 +120,17 @@ module ServerEngine
       end
 
       def send_reload
-        @pmon.send_signal(@reload_signal) if @pmon
+        return nil unless @pmon
+        if @pmon.command_sender_pipe
+          send_command("RELOAD\n")
+        else
+          @pmon.send_signal(@reload_signal)
+        end
         nil
+      end
+
+      def send_command(command)
+        @pmon.send_command(command) if @pmon
       end
 
       def join

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -46,13 +46,6 @@ module ServerEngine
       @pm.command_sender = @command_sender
     end
 
-    def stop(stop_graceful)
-      if @command_sender == "pipe"
-        @pm.command_sender_pipe.write(stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n")
-      end
-      super
-    end
-
     def run
       super
     ensure


### PR DESCRIPTION
This commit intents to fix the following issues of Fluentd:

* https://github.com/fluent/fluentd/issues/3066: Unexpected error Broken pipe when trying to shutdown fluentd with multiple workers
* https://github.com/fluent/fluentd/pull/3131: Add win32 events alternative to unix signals

Current implementation of `MultiSpawnServer` has following issues. This PR fixes these them:

 * multiple workers feature isn't supported correctly on Windows
 * graceful stop & restart aren't supported on Windows
 * reload commands isn't supported on Windows
 
~~In addition, this PR also fixes default behavior of `stop` and `restart` methods of `MultiSpawnServer`.
They do nothing by default because these methods expect that `auto_tick` is enabled although `MultiSpawnServer` disables it by default. When `auto_tick` is disabled, users of this class will expect that it sends a signal (or command) immediately.
(If you don't want to change this behavior, I'll remove this commit.)~~
