### PR TITLE
Tweak SocketManager's port on Windows

### DIFF
--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -72,7 +72,7 @@ module ServerEngine
     class Server
       def self.generate_path
         if ServerEngine.windows?
-          for port in 10000..65535
+          for port in get_dynamic_port_range
             if `netstat -na | findstr "#{port}"`.length == 0
               return port
             end
@@ -159,6 +159,40 @@ module ServerEngine
         end
       ensure
         peer.close
+      end
+
+      if ServerEngine.windows?
+        def self.valid_dynamic_port_range(start_port, end_port)
+          return false if start_port < 1025 or start_port > 65535
+          return false if end_port < 1025 or end_port > 65535
+          return false if start_port > end_port
+          true
+        end
+
+        def self.get_dynamic_port_range
+          numbers = []
+          # Example output of netsh (actual output is localized):
+          #
+          # Protocol tcp Dynamic Port Range
+          # ---------------------------------
+          # Start Port      : 49152
+          # Number of Ports : 16384
+          #
+          str = `netsh int ipv4 show dynamicport tcp`.force_encoding("ASCII-8BIT")
+          str.each_line { |line| numbers << $1.to_i if line.match(/.*: (\d+)/) }
+
+          start_port, n_ports = numbers[0], numbers[1]
+          end_port = start_port + n_ports - 1
+
+          if valid_dynamic_port_range(start_port, end_port)
+            return start_port..end_port
+          else
+            # The default dynamic port range is 49152 - 65535 as of Windows Vista
+            # and Windows Server 2008.
+            # https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/default-dynamic-port-range-tcpip-chang
+            return 49152..65535
+          end
+        end
       end
     end
 

--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -72,6 +72,9 @@ module ServerEngine
     class Server
       def self.generate_path
         if ServerEngine.windows?
+          port = ENV['SERVERENGINE_SOCKETMANAGER_PORT']
+          return port.to_i if port
+
           for port in get_dynamic_port_range
             if `netstat -na | findstr "#{port}"`.length == 0
               return port

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -25,6 +25,13 @@ describe ServerEngine::SocketManager do
         path = SocketManager::Server.generate_path
         expect(path).to be_between(49152, 65535)
       end
+
+      it 'can be changed via environment variable' do
+        ENV['SERVERENGINE_SOCKETMANAGER_PORT'] = '54321'
+        path = SocketManager::Server.generate_path
+        expect(path).to be 54321
+        ENV.delete('SERVERENGINE_SOCKETMANAGER_PORT')
+      end
     end
   else
     context 'Server.generate_path' do

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -19,7 +19,14 @@ describe ServerEngine::SocketManager do
     File.unlink(server_path) if server_path.is_a?(String) && File.exist?(server_path)
   end
 
-  if !ServerEngine.windows?
+  if ServerEngine.windows?
+    context 'Server.generate_path' do
+      it 'returns socket path as port number' do
+        path = SocketManager::Server.generate_path
+        expect(path).to be_between(49152, 65535)
+      end
+    end
+  else
     context 'Server.generate_path' do
       it 'returns socket path under /tmp' do
         path = SocketManager::Server.generate_path


### PR DESCRIPTION
SocketManger on Windows uses TCP to communicate with workers and it uses 10000 port by default.
But this port is known as NDMP(Network Data Management Protocol):
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=10000
and ServerEngine doesn't provide a way to change it manually.

To resolve the conflict this PR includes following two fixes:

* Use dynamic ports according to OS's setting
* Enable to change the port by environment variable `SERVERENGINE_SOCKETMANAGER_PORT`