### PR TITLE
AppVeyor: Use the image "Visual Studio 2019" to use Ruby 3.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 ---
+image: Visual Studio 2019
+
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version


### PR DESCRIPTION
If `image` is omitted, an old one is used unexpectedly.
