### PR TITLE
WinSock: Ensure to retrieve correct error code on Ruby 3.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,20 @@ environment:
     - ruby_version: "27-x64"
     - ruby_version: "26-x64"
     - ruby_version: "25-x64"
+
+# On Ruby 3.0, we need to use fiddle 1.0.8 or later to retrieve correct
+# error code. In addition, we have to specify the path of fiddle by RUBYLIB
+# because RubyInstaller loads Ruby's bundled fiddle before initializing gem.
+# See also:
+# * https://github.com/ruby/fiddle/issues/72
+# * https://bugs.ruby-lang.org/issues/17813
+# * https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
+for:
+-
+  matrix:
+    only:
+      - ruby_version: "30-x64"
+  test_script:
+    - gem install fiddle --version 1.0.8
+    - set RUBYLIB=C:/Ruby%ruby_version%/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
+    - bundle exec rake spec

--- a/spec/winsock_spec.rb
+++ b/spec/winsock_spec.rb
@@ -1,0 +1,18 @@
+require 'windows/error' if ServerEngine.windows?
+
+describe ServerEngine::WinSock do
+  # On Ruby 3.0, you need to use fiddle 1.0.8 or later to retrieve a correct
+  # error code. In addition, you need to specify the path of fiddle by RUBYLIB
+  # or `ruby -I` when you use RubyInstaller because it loads Ruby's bundled
+  # fiddle before initializing gem.
+  # See also:
+  # * https://github.com/ruby/fiddle/issues/72
+  # * https://bugs.ruby-lang.org/issues/17813
+  # * https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
+  context 'last_error' do
+    it 'bind error' do
+      expect(WinSock.bind(0, nil, 0)).to be -1
+      expect(WinSock.last_error).to be Windows::Error::WSAENOTSOCK
+    end
+  end
+end if ServerEngine.windows?


### PR DESCRIPTION
On Ruby 3.0, calling WSAGetLastError from Ruby script cannot get a
correct error code because Ruby's internal code resets it. Use
`Fiddle.win32_last_socket_error` instead if it's availbale.
You need fiddle 1.0.8 or later to use it. In addition, when you use
RubyInstaller, you need to specify the path of fiddle by `RUBYLIB` or
`ruby -I` at this moment because it loads Ruby's bundled fiddle before
initializing gem. This is the why we don't add a dependency to fiddle,
just only installing fiddle doesn't take effect.

e.g.)

  > gem install fiddle --version 1.0.8
  > set RUBYLIB=C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/fiddle-1.0.8/lib
  > bundle exec rake spec

See also:
* https://github.com/ruby/fiddle/issues/72
* https://bugs.ruby-lang.org/issues/17813
* https://github.com/oneclick/rubyinstaller2/blob/8225034c22152d8195bc0aabc42a956c79d6c712/lib/ruby_installer/build/dll_directory.rb
