### PR TITLE
Treat as error when  worker is shut down unexpectedly

### DIFF
--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -142,7 +142,11 @@ module ServerEngine
         return false unless @pmon
 
         if stat = @pmon.try_join
-          @worker.logger.info "Worker #{@wid} finished#{@stop ? '' : ' unexpectedly'} with #{ServerEngine.format_join_status(stat)}"
+          if @stop
+            @worker.logger.info "Worker #{@wid} finished with #{ServerEngine.format_join_status(stat)}"
+          else
+            @worker.logger.error "Worker #{@wid} finished unexpectedly with #{ServerEngine.format_join_status(stat)}"
+          end
           if stat.is_a?(Process::Status) && stat.exited? && @unrecoverable_exit_codes.include?(stat.exitstatus)
             @unrecoverable_exit = true
             @exitstatus = stat.exitstatus


### PR DESCRIPTION
Before

[2021-09-01T15:24:37.939197 #133886] INFO -- : Worker 0 finished unexpectedly with status 5

After

[2021-09-01T15:24:37.939197 #133886] ERROR -- : Worker 0 finished unexpectedly with status 5
