### PR TITLE
Fix an unstable test on Windows

### DIFF
--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -197,7 +197,13 @@ describe ServerEngine::Supervisor do
           t.join
         end
 
-        test_state(:worker_run).should == 3
+        if ServerEngine.windows?
+          # Because launching a process on Windows is high cost,
+          # it doesn't often reach to 3.
+          test_state(:worker_run).should <= 3
+        else
+          test_state(:worker_run).should == 3
+        end
       end
     end
   end


### PR DESCRIPTION
e.g.) https://github.com/treasure-data/serverengine/runs/4799700979?check_suite_focus=true

```
  1) ServerEngine::Supervisor when using pipe as command_sender auto restart in limited ratio
     Failure/Error: test_state(:worker_run).should == 3
       expected: 3
            got: 2 (using ==)
     # ./spec/supervisor_spec.rb:200:in `block (4 levels) in <top (required)>'
```

This is becuase lauching a process on Windows is high cost. But it's not
need to be exactly 3 because it tests limiting too frequent restart.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>