### PR TITLE
Require utils to not raise NoMethodError for ServerEngine.windows?

### DIFF
--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -22,6 +22,8 @@ require 'securerandom'
 require 'json'
 require 'base64'
 
+require_relative 'utils' # for ServerEngine.windows?
+
 module ServerEngine
   module SocketManager
     # This token is used for communication between peers. If token is mismatched, messages will be discarded


### PR DESCRIPTION
Just requiring `serverengine/socket_manager` raises NoMethodError without `utils`.

Signed-off-by: Satoshi Moris Tagomori <tagomoris@gmail.com>