### PR TITLE
Suppress a error of command pipe on shutdown

### DIFF
--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -80,7 +80,7 @@ module ServerEngine
       if @command_pipe
         Thread.new do
           until @command_pipe.closed?
-            case @command_pipe.gets.chomp
+            case @command_pipe.gets&.chomp
             when "GRACEFUL_STOP"
               s.stop(true)
             when "IMMEDIATE_STOP"


### PR DESCRIPTION
```
  D:/a/serverengine/serverengine/lib/serverengine/server.rb:83:in `block in install_signal_handlers': undefined method `chomp' for nil:NilClass (NoMethodError)
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>