### PR TITLE
Fix a warning while running test

### DIFF
--- a/spec/server_worker_context.rb
+++ b/spec/server_worker_context.rb
@@ -256,10 +256,12 @@ shared_context 'test server and worker' do
   before { reset_test_state }
   after { Timecop.return }
 
-  if ServerEngine.windows?
-    WAIT_RATIO = 2
-  else
-    WAIT_RATIO = 1
+  unless self.const_defined?(:WAIT_RATIO)
+    if ServerEngine.windows?
+      WAIT_RATIO = 2
+    else
+      WAIT_RATIO = 1
+    end
   end
 
   def wait_for_fork


### PR DESCRIPTION
```
C:/Users/aho/Projects/serverengine/spec/server_worker_context.rb:260: warning: already initialized constant WAIT_RATIO
C:/Users/aho/Projects/serverengine/spec/server_worker_context.rb:260: warning: previous definition of WAIT_RATIO was here
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>