### PR TITLE
Add spawn worker-type to one server configurations block

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Available methods are different depending on `worker_type`. ServerEngine support
   - **disable_reload** disables USR2 signal (default: false)
   - **server_restart_wait** sets wait time before restarting server after last restarting (default: 1.0) [dynamic reloadable]
   - **server_detach_wait** sets wait time before starting live restart (default: 10.0) [dynamic reloadable]
-- Multithread server and multiprocess server: available only when `worker_type` is thread or process
+- Multithread server and multiprocess server: available only when `worker_type` is "thread" or "process" or "spawn"
   - **workers** sets number of workers (default: 1) [dynamic reloadable]
   - **start_worker_delay** sets the delay between each worker-start when starting/restarting multiple workers at once (default: 0) [dynamic reloadable]
   - **start_worker_delay_rand** randomizes start_worker_delay at this ratio (default: 0.2) [dynamic reloadable]


### PR DESCRIPTION
These configs can be used in "spawn" worker-type too.

```
- Multithread server and multiprocess server: available only when `worker_type` is thread or process
  - **workers** sets number of workers (default: 1) [dynamic reloadable]
  - **start_worker_delay** sets the delay between each worker-start when starting/restarting multiple workers at once (default: 0) [dynamic reloadable]
  - **start_worker_delay_rand** randomizes start_worker_delay at this ratio (default: 0.2) [dynamic reloadable]
  - **restart_worker_interval** sets wait time before restarting a stopped worker (default: 0) [dynamic reloadable]
```