### PR TITLE
Fix behavior of start_worker_delay option

### DIFF
--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -160,12 +160,10 @@ module ServerEngine
           Kernel.rand * @start_worker_delay * @start_worker_delay_rand -
           @start_worker_delay * @start_worker_delay_rand / 2
 
-        now = Time.now.to_f
-
-        wait = delay - (now - @last_start_worker_time)
+        wait = delay - (Time.now.to_f - @last_start_worker_time)
         sleep wait if wait > 0
 
-        @last_start_worker_time = now
+        @last_start_worker_time = Time.now.to_f
       end
 
       @monitors[wid] = start_worker(wid)


### PR DESCRIPTION
The behavior of `start_worker_delay` is a little weird.

While not a major problem, there seems to be a minor mistake in the implementation.

Although Fluentd doesn't use this option,
if we use the option as follows, then this works as follows.

```diff
--- a/lib/fluent/supervisor.rb
+++ b/lib/fluent/supervisor.rb
@@ -494,7 +494,8 @@ module Fluent
         main_cmd: params['main_cmd'],
         signame: params['signame'],
-        disable_shared_socket: params['disable_shared_socket']
+        disable_shared_socket: params['disable_shared_socket'],
+        start_worker_delay: 3
       }
       if daemonize
         se_config[:pid_path] = pid_path
```

**The current behavior**

```
2022-06-10 16:02:08 +0900 [info]: using configuration file: <ROOT>
  <system>
    workers 6
  </system>
  <source>
    @type forward
    port 24224
    bind "0.0.0.0"
  </source>
  <match test.**>
    @type stdout
  </match>
</ROOT>
2022-06-10 16:02:08 +0900 [info]: starting fluentd-1.14.6 pid=353261 ruby="2.7.5"
2022-06-10 16:02:08 +0900 [info]: #0 fluentd worker is now running worker=0
2022-06-10 16:02:11 +0900 [info]: #2 fluentd worker is now running worker=2
2022-06-10 16:02:11 +0900 [info]: #1 fluentd worker is now running worker=1
2022-06-10 16:02:14 +0900 [info]: #4 fluentd worker is now running worker=4
2022-06-10 16:02:14 +0900 [info]: #3 fluentd worker is now running worker=3
2022-06-10 16:02:17 +0900 [info]: #5 fluentd worker is now running worker=5
```

* The next 2 workers start at the same time.

**The behavior with this fix**

```
2022-06-10 15:56:47 +0900 [info]: using configuration file: <ROOT>
  <system>
    workers 6
  </system>
  <source>
    @type forward
    port 24224
    bind "0.0.0.0"
  </source>
  <match test.**>
    @type stdout
  </match>
</ROOT>
2022-06-10 15:56:47 +0900 [info]: starting fluentd-1.14.6 pid=352530 ruby="2.7.5"
2022-06-10 15:56:47 +0900 [info]: #0 fluentd worker is now running worker=0
2022-06-10 15:56:50 +0900 [info]: #1 fluentd worker is now running worker=1
2022-06-10 15:56:53 +0900 [info]: #2 fluentd worker is now running worker=2
2022-06-10 15:56:56 +0900 [info]: #3 fluentd worker is now running worker=3
2022-06-10 15:56:59 +0900 [info]: #4 fluentd worker is now running worker=4
2022-06-10 15:57:02 +0900 [info]: #5 fluentd worker is now running worker=5
```

* They are cleanly separated by 3 seconds.
