### PR TITLE
Treat worker unexpected shutdown as Warn log level

### DIFF
--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -147,7 +147,11 @@ module ServerEngine
           if @stop
             @worker.logger.info "Worker #{@wid} finished with #{ServerEngine.format_join_status(stat)}"
           else
-            @worker.logger.warn "Worker #{@wid} finished unexpectedly with #{ServerEngine.format_join_status(stat)}"
+            if stat.is_a?(Process::Status) && stat.success?
+              @worker.logger.info "Worker #{@wid} finished with #{ServerEngine.format_join_status(stat)}"
+            else
+              @worker.logger.error "Worker #{@wid} finished unexpectedly with #{ServerEngine.format_join_status(stat)}"
+            end
           end
           if stat.is_a?(Process::Status) && stat.exited? && @unrecoverable_exit_codes.include?(stat.exitstatus)
             @unrecoverable_exit = true

--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -147,7 +147,7 @@ module ServerEngine
           if @stop
             @worker.logger.info "Worker #{@wid} finished with #{ServerEngine.format_join_status(stat)}"
           else
-            @worker.logger.error "Worker #{@wid} finished unexpectedly with #{ServerEngine.format_join_status(stat)}"
+            @worker.logger.warn "Worker #{@wid} finished unexpectedly with #{ServerEngine.format_join_status(stat)}"
           end
           if stat.is_a?(Process::Status) && stat.exited? && @unrecoverable_exit_codes.include?(stat.exitstatus)
             @unrecoverable_exit = true

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -1,3 +1,6 @@
+require 'timeout'
+require 'securerandom'
+
 [ServerEngine::MultiThreadServer, ServerEngine::MultiProcessServer].each do |impl_class|
   # MultiProcessServer uses fork(2) internally, then it doesn't support Windows.
 
@@ -109,5 +112,103 @@
       raised_error.should_not be_nil
       raised_error.status.should == 5 # 1st process's exit status
     end
+  end
+end
+
+describe "log level for exited proccess" do
+  include_context 'test server and worker'
+
+  before do
+    @log_path = "tmp/multi-process-log-level-test-#{SecureRandom.hex(10)}.log"
+  end
+
+  after do
+    FileUtils.rm_rf(@log_path)
+  end
+
+  it 'stop' do
+    pending "Windows environment does not support fork" if ServerEngine.windows?
+
+    config = {
+      workers: 1,
+      logger: ServerEngine::DaemonLogger.new(@log_path),
+      log_stdout: false,
+      log_stderr: false,
+    }
+
+    s = ServerEngine::MultiProcessServer.new(TestWorker) { config.dup }
+    t = Thread.new { s.main }
+
+    begin
+      wait_for_fork
+      test_state(:worker_run).should == 1
+    ensure
+      s.stop(true)
+      t.join
+    end
+
+    log_lines = File.read(@log_path).split("\n")
+    expect(log_lines[2]).to match(/^I, \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+ #\d+\]  INFO -- : Worker 0 finished with status 0$/)
+  end
+
+  it 'non zero exit status' do
+    pending "Windows environment does not support fork" if ServerEngine.windows?
+
+    config = {
+      workers: 1,
+      logger: ServerEngine::DaemonLogger.new(@log_path),
+      log_stdout: false,
+      log_stderr: false,
+      unrecoverable_exit_codes: [5],
+    }
+
+    s = ServerEngine::MultiProcessServer.new(TestExitWorker) { config.dup }
+    raised_error = nil
+    Thread.new do
+      begin
+        s.main
+      rescue SystemExit => e
+        raised_error = e
+      end
+    end.join
+
+    test_state(:worker_stop).to_i.should == 0
+    raised_error.status.should == 5
+    log_lines = File.read(@log_path).split("\n")
+    expect(log_lines[1]).to match(/^E, \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+ #\d+\] ERROR -- : Worker 0 finished unexpectedly with status 5$/)
+  end
+
+  module TestNormalExitWorker
+    include TestExitWorker
+    def initialize
+      super
+      @exit_code = 0
+    end
+  end
+
+  it 'zero exit status' do
+    pending "Windows environment does not support fork" if ServerEngine.windows?
+
+    config = {
+      workers: 1,
+      logger: ServerEngine::DaemonLogger.new(@log_path),
+      log_stdout: false,
+      log_stderr: false,
+    }
+
+    s = ServerEngine::MultiProcessServer.new(TestNormalExitWorker) { config.dup }
+    t = Thread.new { s.main }
+
+    begin
+      Timeout.timeout(5) do
+        sleep 1 until File.read(@log_path).include?("INFO -- : Worker 0 finished with status 0")
+      end
+    ensure
+      s.stop(true)
+      t.join
+    end
+
+    log_lines = File.read(@log_path).split("\n")
+    expect(log_lines[1]).to match(/^I, \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+ #\d+\]  INFO -- : Worker 0 finished with status 0$/)
   end
 end


### PR DESCRIPTION
This log level was changed to ERROR by the fix: #113.

However, this log is outputted when using SIGHUP, so ERROR is too strong. Leave it as Warn as an adjustment for now.

* https://docs.fluentd.org/deployment/signals

Before

    2022-11-29 18:47:47 +0900 [error]: fluent/log.rb:372:error: Worker 0 finished unexpectedly with status 0

After

    2022-11-29 18:45:42 +0900 [warn]: fluent/log.rb:351:warn: Worker 0 finished unexpectedly with status 0
