### PR TITLE
Suppress needless log output while testing

### DIFF
--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake-compiler', ['~> 0.9.4']
 
   gem.add_development_dependency "timecop", ["~> 0.9.5"]
+  gem.add_development_dependency "rr", ["~> 3.1"]
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -2,6 +2,14 @@
 describe ServerEngine::Daemon do
   include_context 'test server and worker'
 
+  before do
+    @log_path = "tmp/multi-worker-test-#{SecureRandom.hex(10)}.log"
+  end
+
+  after do
+    FileUtils.rm_rf(@log_path)
+  end
+
   it 'run and graceful stop by signal' do
     pending "not supported signal base commands on Windows" if ServerEngine.windows?
 
@@ -111,6 +119,7 @@ describe ServerEngine::Daemon do
       daemonize: false,
       supervisor: false,
       pid_path: "tmp/pid",
+      logger: ServerEngine::DaemonLogger.new(@log_path),
       log_stdout: false,
       log_stderr: false,
       unrecoverable_exit_codes: [3,4,5],
@@ -135,6 +144,7 @@ describe ServerEngine::Daemon do
       supervisor: false,
       worker_type: 'process',
       pid_path: "tmp/pid",
+      logger: ServerEngine::DaemonLogger.new(@log_path),
       log_stdout: false,
       log_stderr: false,
       unrecoverable_exit_codes: [3,4,5],
@@ -158,6 +168,7 @@ describe ServerEngine::Daemon do
       supervisor: true,
       worker_type: 'process',
       pid_path: "tmp/pid",
+      logger: ServerEngine::DaemonLogger.new(@log_path),
       log_stdout: false,
       log_stderr: false,
       unrecoverable_exit_codes: [3,4,5],

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -81,9 +81,23 @@ require 'securerandom'
 
       test_state(:worker_stop).should == 3
     end
+  end
+end
+
+[ServerEngine::MultiProcessServer].each do |impl_class|
+  describe impl_class do
+    include_context 'test server and worker'
+
+    before do
+      @log_path = "tmp/multi-worker-test-#{SecureRandom.hex(10)}.log"
+      @logger = ServerEngine::DaemonLogger.new(@log_path)
+    end
+
+    after do
+      FileUtils.rm_rf(@log_path)
+    end
 
     it 'raises SystemExit when all workers exit with specified code by unrecoverable_exit_codes' do
-      pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
       config = {
@@ -113,7 +127,6 @@ require 'securerandom'
     end
 
     it 'raises SystemExit immediately when a worker exits if stop_immediately_at_unrecoverable_exit specified' do
-      pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
       config = {

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -7,10 +7,24 @@ require 'securerandom'
   describe impl_class do
     include_context 'test server and worker'
 
+    before do
+      @log_path = "tmp/multi-worker-test-#{SecureRandom.hex(10)}.log"
+      @logger = ServerEngine::DaemonLogger.new(@log_path)
+    end
+
+    after do
+      FileUtils.rm_rf(@log_path)
+    end
+
     it 'scale up' do
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
-      config = {workers: 2, log_stdout: false, log_stderr: false}
+      config = {
+        workers: 2,
+        logger: @logger,
+        log_stdout: false,
+        log_stderr: false,
+      }
 
       s = impl_class.new(TestWorker) { config.dup }
       t = Thread.new { s.main }
@@ -38,7 +52,12 @@ require 'securerandom'
     it 'scale down' do
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
-      config = {workers: 2, log_stdout: false, log_stderr: false}
+      config = {
+        workers: 2,
+        logger: @logger,
+        log_stdout: false,
+        log_stderr: false
+      }
 
       s = impl_class.new(TestWorker) { config.dup }
       t = Thread.new { s.main }
@@ -67,7 +86,13 @@ require 'securerandom'
       pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
-      config = {workers: 4, log_stdout: false, log_stderr: false, unrecoverable_exit_codes: [3, 4, 5]}
+      config = {
+        workers: 4,
+        logger: @logger,
+        log_stdout: false,
+        log_stderr: false,
+        unrecoverable_exit_codes: [3, 4, 5]
+      }
 
       s = impl_class.new(TestExitWorker) { config.dup }
       raised_error = nil
@@ -91,7 +116,14 @@ require 'securerandom'
       pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
       pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
-      config = {workers: 4, log_stdout: false, log_stderr: false, unrecoverable_exit_codes: [3, 4, 5], stop_immediately_at_unrecoverable_exit: true}
+      config = {
+        workers: 4,
+        logger: @logger,
+        log_stdout: false,
+        log_stderr: false,
+        unrecoverable_exit_codes: [3, 4, 5],
+        stop_immediately_at_unrecoverable_exit: true
+      }
 
       s = impl_class.new(TestExitWorker) { config.dup }
       raised_error = nil

--- a/spec/multi_spawn_server_spec.rb
+++ b/spec/multi_spawn_server_spec.rb
@@ -4,10 +4,25 @@ require 'timecop'
 describe ServerEngine::MultiSpawnServer do
   include_context 'test server and worker'
 
+  before do
+    @log_path = "tmp/multi-worker-test-#{SecureRandom.hex(10)}.log"
+    @logger = ServerEngine::DaemonLogger.new(@log_path)
+  end
+
+  after do
+    FileUtils.rm_rf(@log_path)
+  end
+
   describe 'starts worker processes' do
     context 'with command_sender=pipe' do
       it do
-        config = {workers: 2, command_sender: 'pipe', log_stdout: false, log_stderr: false}
+        config = {
+          workers: 2,
+          command_sender: 'pipe',
+          logger: @logger,
+          log_stdout: false,
+          log_stderr: false
+        }
 
         s = ServerEngine::MultiSpawnServer.new(TestWorker) { config.dup }
         t = Thread.new { s.main }
@@ -32,6 +47,7 @@ describe ServerEngine::MultiSpawnServer do
       {
         workers: workers,
         command_sender: 'pipe',
+        logger: @logger,
         log_stdout: false,
         log_stderr: false,
         start_worker_delay: start_worker_delay,

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -3,6 +3,9 @@ describe ServerEngine::Supervisor do
   include_context 'test server and worker'
 
   def start_supervisor(worker = nil, **config)
+    config[:log] ||= @log_path
+    config[:log_stdout] ||= false
+    config[:log_stderr] ||= false
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_supervisor_cmdline(nil, worker, config)
     end
@@ -13,6 +16,8 @@ describe ServerEngine::Supervisor do
   end
 
   def start_daemon(**config)
+    config[:log_stdout] ||= false
+    config[:log_stderr] ||= false
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_daemon_cmdline
     end
@@ -22,9 +27,17 @@ describe ServerEngine::Supervisor do
     return daemon, t
   end
 
+  before do
+    @log_path = "tmp/supervisor-test-#{SecureRandom.hex(10)}.log"
+  end
+
+  after do
+    FileUtils.rm_rf(@log_path)
+  end
+
   context 'when :log=IO option is given' do
     it 'can start' do
-      daemon, t = start_daemon(log: STDOUT)
+      daemon, t = start_daemon(log: File.open(@log_path, "wb"))
 
       begin
         wait_for_fork
@@ -40,7 +53,7 @@ describe ServerEngine::Supervisor do
 
   context 'when :logger option is given' do
     it 'uses specified logger instance' do
-      logger = ServerEngine::DaemonLogger.new(STDOUT)
+      logger = ServerEngine::DaemonLogger.new(@log_path)
       daemon, t = start_daemon(logger: logger)
 
       begin
@@ -57,7 +70,7 @@ describe ServerEngine::Supervisor do
 
   context 'when both :logger and :log options are given' do
     it 'start ignoring :log' do
-      logger = ServerEngine::DaemonLogger.new(STDOUT)
+      logger = ServerEngine::DaemonLogger.new(@log_path)
       daemon, t = start_daemon(logger: logger, log: STDERR)
 
       begin

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -1,3 +1,4 @@
+require 'rr'
 
 describe ServerEngine::Supervisor do
   include_context 'test server and worker'
@@ -200,6 +201,8 @@ describe ServerEngine::Supervisor do
 
       it 'auto restart in limited ratio' do
         pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        RR.stub(ServerEngine).dump_uncaught_error
 
         sv, t = start_supervisor(RunErrorWorker, server_restart_wait: 1, command_sender: sender)
 


### PR DESCRIPTION
Although many logs are output to console while running `bundle exec rake spec`, most of them aren't need to show. Such verbose output is confusing for finding messages of real issues.

In addion, output them to a file is convenient to check log messages in unit tests.
