### PR TITLE
Update required Ruby version to 2.3.0

### DIFF
--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.1.0"
+  gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency "sigdump", ["~> 0.2.2"]
 


### PR DESCRIPTION
When I was matrix-testing a gem depending on `serverengine`,
I found that this gem no longer works with Ruby under 2.3.

This is because a safe navigation operator ( `&.` )
is used at the following line.

https://github.com/treasure-data/serverengine/blob/c35e3a523958a82b6e27580f8197d66e601a0092/lib/serverengine/server.rb#L83

Based on the current Ruby versions used in CI,
IMHO, I thought it is about a time to increment the required ruby version to 2.3.

https://github.com/treasure-data/serverengine/blob/c35e3a523958a82b6e27580f8197d66e601a0092/.github/workflows/linux.yml#L14

If this is against the policy of `serverengine`, I would like to fix the issue as follows.

```diff
- case @command_pipe.gets&.chomp
+ case (@command_pipe.gets || "").chomp
```

In my local Mac, `bundle exec rspec` has passed with Ruby 2.3.1.