### PR TITLE
SocketManager: Enable `open(nil)` to select path automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ se.run
 ```ruby
 module MyServer
   def before_run
-    @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-    @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
+    @socket_manager_server = ServerEngine::SocketManager::Server.open
+    @socket_manager_path = @socket_manager_server.path
   end
 
   def after_run

--- a/examples/server.rb
+++ b/examples/server.rb
@@ -41,8 +41,8 @@ module MyServer
   attr_reader :socket_manager_path
 
   def before_run
-    @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
-    @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
+    @socket_manager_server = ServerEngine::SocketManager::Server.open
+    @socket_manager_path = @socket_manager_server.path
   rescue Exception => e
     logger.error "unexpected error in server, class #{e.class}: #{e.message}"
     raise

--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -88,8 +88,13 @@ module ServerEngine
         end
       end
 
-      def self.open(path)
-        new(path)
+      def self.open(path = nil)
+        return new(path) unless path.nil?
+        if ServerEngine.windows?
+          new(0)
+        else
+          new(self.generate_path)
+        end
       end
 
       def initialize(path)

--- a/lib/serverengine/socket_manager_win.rb
+++ b/lib/serverengine/socket_manager_win.rb
@@ -108,8 +108,9 @@ module ServerEngine
       end
 
       def start_server(addr)
-        # TODO: use TCPServer, but this is risky because using not conflict path is easy,
-        # but using not conflict port is difficult. Then We had better implement using NamedPipe.
+        # We need to take care about selecting an available port.
+        # By passing `nil` or `0` as `addr`, an available port is automatically selected.
+        # However, we should consider using NamedPipe instead of TCPServer.
         @server = TCPServer.new("127.0.0.1", addr)
         @thread = Thread.new do
           begin
@@ -123,7 +124,7 @@ module ServerEngine
           end
         end
 
-        return path
+        return @server.addr[1]
       end
 
       def stop_server

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -33,6 +33,13 @@ describe ServerEngine::SocketManager do
         ENV.delete('SERVERENGINE_SOCKETMANAGER_PORT')
       end
     end
+
+    context 'Server.open' do
+      it 'returns server with automatically selected socket path as port number' do
+        server = SocketManager::Server.open
+        expect(server.path).to be_between(49152, 65535)
+      end
+    end
   else
     context 'Server.generate_path' do
       it 'returns socket path under /tmp' do
@@ -45,6 +52,13 @@ describe ServerEngine::SocketManager do
         path = SocketManager::Server.generate_path
         expect(path).to include('/tmp/foo/SERVERENGINE_SOCKETMANAGER_')
         ENV.delete('SERVERENGINE_SOCKETMANAGER_SOCK_DIR')
+      end
+    end
+
+    context 'Server.open' do
+      it 'returns server with automatically selected socket path under /tmp' do
+        server = SocketManager::Server.open
+        expect(server.path).to include('/tmp/SERVERENGINE_SOCKETMANAGER_')
       end
     end
   end


### PR DESCRIPTION
* Fixes #140.

I already created

* #142

but we need a more fundamental solution as discussed in #140.

This PR enables `ServerEngine::SocketManager::Server.open(nil)` to select `path` automatically.

Especially on Windows, it is hard to search an available port for `path`, so we should use this feature.
(The current `generate_path` logic sometimes chooses an unavailable port. For example, it does not consider the excluded port range.)

This fix keeps backward compatibility.
