### PR TITLE
socket_manager: add feature to take over another server

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,14 @@ se = ServerEngine.create(MyServer, MyWorker, {
 se.run
 ```
 
-See also [examples](https://github.com/fluent/serverengine/tree/master/examples).
+Other features:
 
+- `socket_manager_server = SocketManager::Server.take_over_another_server(path)`
+  - It starts a new manager server that has all UDP/TCP sockets of the existing manager.
+  - It receives the sockets and stops the existing manager after starts a new manager.
+  - It means that another process can take over UDP/TCP sockets without downtime.
+
+See also [examples](https://github.com/fluent/serverengine/tree/master/examples).
 
 ## Module API
 


### PR DESCRIPTION
Another process can take over UDP/TCP sockets without downtime.

    server = ServerEngine::SocketManager::Server.take_over_another_server(path)

This starts a new server that has all UDP/TCP sockets of the existing server.
It receives the sockets from the existing server and stops it after starts a new server.

This may not be the primary use case assumed by ServerEngine, but we need this feature to replace both the server and the workers with a new process without downtime.
Currently, ServerEngine does not provide this feature for network servers.

At the moment, I assume that the application side uses this feature ad hoc, but, in the future, this could be used to support live reload for entire network servers.

* ref: https://github.com/fluent/fluentd/issues/4622