### PR TITLE
Add base64 and logger gem as dependency for Ruby 3.4 and 3.5

### DIFF
--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency "sigdump", ["~> 0.2.2"]
+  gem.add_dependency "base64", ["~> 0.1"]
+  gem.add_dependency "logger", ["~> 1.4"]
 
   # rake v12.x doesn't work with rspec 2. rspec should be updated to 3
   gem.add_development_dependency "rake", ["~> 13.0"]


### PR DESCRIPTION
The `base64` gem was marked as bundled gem for Ruby 3.4.
Ref. https://github.com/ruby/ruby/commit/6500f85927135901f365d2ba1186c5c4f2881f8e

And, the `logger` gem was marked as bundled gem for Ruby 3.5.
Ref. https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c

This patch will suppress the following warning message:

```
socket_manager.rb:23: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.

config_loader.rb:18: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```
