### PR TITLE
socket_manager: add feature to share sockets with another server

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,15 @@ se = ServerEngine.create(MyServer, MyWorker, {
 se.run
 ```
 
-See also [examples](https://github.com/fluent/serverengine/tree/master/examples).
+Other features:
 
+- `socket_manager_server = SocketManager::Server.share_sockets_with_another_server(path)`
+  - It starts a new manager server that shares all UDP/TCP sockets with the existing manager.
+  - We can use this for live restart for network servers.
+  - The old process should stop without removing the file for the socket after the new process starts.
+  - Limitation: This feature would not work well if the process opens new TCP ports frequently.
+
+See also [examples](https://github.com/fluent/serverengine/tree/master/examples).
 
 ## Module API
 


### PR DESCRIPTION
Another process can take over UDP/TCP sockets without downtime.

    server = ServerEngine::SocketManager::Server.share_sockets_with_another_server(path)

This starts a new server that shares all UDP/TCP sockets with the existing server.
The old process should stop without removing the file for the socket after the new process starts.

This allows us to replace both the server and the workers with new processes without socket downtime.
(The existing live restart feature does not support network servers.
We can restart workers without socket downtime, but there is no such way for the network server.)

ref: https://github.com/fluent/fluentd/issues/4622

# Limitation

* This feature would not work well if the process opens new TCP ports frequently.
  * If a client listens to a new socket during the sharing process, the new socket may not take over.
  * If this happens ...
    * Safe case: After the old server stops, the new server re-opens it.
    * Unsafe case: The new server tries to re-open it before the old server stops and causes `address already in use` error.
* The old process must not remove the socket file when it stops.

# TODO

- [x] Add tests
- [x] Consider limitations
- [x] Consider exclusive lock